### PR TITLE
Make it run as one worker instead of two

### DIFF
--- a/lib/bbconnect_sync/workers/csv_writer.rb
+++ b/lib/bbconnect_sync/workers/csv_writer.rb
@@ -17,7 +17,7 @@ module BBConnectSync
       def perform
         if Settings.worker.enabled
           if file_path = @synchronizer.sync!
-            CSVUploader.perform_async(file_path)
+            CSVUploader.new.perform(file_path)
           end
         end
       end

--- a/lib/bbconnect_sync/workers/csv_writer.rb
+++ b/lib/bbconnect_sync/workers/csv_writer.rb
@@ -17,6 +17,9 @@ module BBConnectSync
       def perform
         if Settings.worker.enabled
           if file_path = @synchronizer.sync!
+            # It would be nice to run this asynchronously but in a load balanced situation
+            # we can't guarantee that the file wasn't written onto a different server.
+            # Until we have a shared files directory, this is the best workaround.
             CSVUploader.new.perform(file_path)
           end
         end


### PR DESCRIPTION
Having two workers is a nice pattern but it causes problemse when there are more than one sidekiq server and they don't share a files directory. For now the best solution is to run CSVUploader synchronously.